### PR TITLE
Reuse computed module info

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ function prepareStackTraceWithSourceModules(error: Error, frames: CallSite[]): s
 
   const moduleInformation = collectModuleInformation(frames);
   if (moduleInformation) {
-    return originalStack + '\n' + collectModuleInformation(frames);
+    return originalStack + '\n' + moduleInformation;
   }
 
   return originalStack;


### PR DESCRIPTION
Fix to re-use the already computed module info rather than re-running it. We'll avoid walking the frame stack and constructing the set twice